### PR TITLE
ConnectionEventListener null safety issue

### DIFF
--- a/android/src/main/kotlin/com/github/chinloyal/pusher_client/pusher/listeners/ConnectionListener.kt
+++ b/android/src/main/kotlin/com/github/chinloyal/pusher_client/pusher/listeners/ConnectionListener.kt
@@ -36,13 +36,13 @@ class ConnectionListener: ConnectionEventListener {
         }
     }
 
-    override fun onError(message: String, code: String, ex: Exception) {
+    override fun onError(message: String, code: String?, ex: Exception?) {
         Handler(Looper.getMainLooper()).post {
             try {
                 val connectionError = JSONObject(mapOf(
                         "message" to message,
                         "code" to code,
-                        "exception" to ex.message
+                        "exception" to ex?.message
                 ))
 
                 debugLog("[ON_ERROR]: message: $message, code: $code")


### PR DESCRIPTION
As seen here https://github.com/pusher/pusher-websocket-java/blob/master/src/main/java/com/pusher/client/connection/ConnectionEventListener.java
code and exception can be null.

This can be tested if while connected to pusher you close your internet connection. The error from the underlying websocket library has a null exception and code.