### PR TITLE
Fix reconnecting issues

### DIFF
--- a/android/src/main/kotlin/com/github/chinloyal/pusher_client/pusher/PusherService.kt
+++ b/android/src/main/kotlin/com/github/chinloyal/pusher_client/pusher/PusherService.kt
@@ -29,7 +29,7 @@ const val PRESENCE_PREFIX = "presence-"
 
 class PusherService : MChannel {
     private var _pusherInstance: Pusher? = null
-    private var _connectionListener: ConnectionListener = ConnectionListener()
+    private var _connectionListener: ConnectionListener? = null
 
     companion object {
         var enableLogging: Boolean = false
@@ -76,6 +76,8 @@ class PusherService : MChannel {
     }
 
     private fun init(call: MethodCall, result: Result) {
+        _connectionListener = ConnectionListener()
+
         // toString works because this is json encoded in dart
         val args = JSONObject(call.arguments.toString())
         val initArgs: JSONObject = args.getJSONObject("initArgs")

--- a/android/src/main/kotlin/com/github/chinloyal/pusher_client/pusher/PusherService.kt
+++ b/android/src/main/kotlin/com/github/chinloyal/pusher_client/pusher/PusherService.kt
@@ -29,6 +29,7 @@ const val PRESENCE_PREFIX = "presence-"
 
 class PusherService : MChannel {
     private var _pusherInstance: Pusher? = null
+    private var _connectionListener: ConnectionListener = ConnectionListener()
 
     companion object {
         var enableLogging: Boolean = false
@@ -120,7 +121,12 @@ class PusherService : MChannel {
     }
 
     private fun connect(result: Result) {
-        _pusherInstance?.connect(ConnectionListener(), ConnectionState.ALL)
+        _pusherInstance?.connect(_connectionListener, ConnectionState.ALL)
+        result.success(null)
+    }
+
+    private fun reconnect(result: Result) {
+        _pusherInstance?.connect()
         result.success(null)
     }
 
@@ -174,7 +180,7 @@ class PusherService : MChannel {
     private fun unsubscribe(call: MethodCall, result: Result) {
         try {
             val src = call.arguments as Map<String, Any>
-            val args = JSONObject(src);
+            val args = JSONObject(src)
             val channelName = args.getString("channelName")
 
             _pusherInstance?.unsubscribe(channelName)

--- a/android/src/main/kotlin/com/github/chinloyal/pusher_client/pusher/PusherService.kt
+++ b/android/src/main/kotlin/com/github/chinloyal/pusher_client/pusher/PusherService.kt
@@ -125,11 +125,6 @@ class PusherService : MChannel {
         result.success(null)
     }
 
-    private fun reconnect(result: Result) {
-        _pusherInstance?.connect()
-        result.success(null)
-    }
-
     private fun disconnect(result: Result) {
         _pusherInstance?.disconnect()
         debugLog("Disconnect")

--- a/android/src/main/kotlin/com/github/chinloyal/pusher_client/pusher/PusherService.kt
+++ b/android/src/main/kotlin/com/github/chinloyal/pusher_client/pusher/PusherService.kt
@@ -29,7 +29,7 @@ const val PRESENCE_PREFIX = "presence-"
 
 class PusherService : MChannel {
     private var _pusherInstance: Pusher? = null
-    private var _connectionListener: ConnectionListener? = null
+    private var _connectionListener: ConnectionListener? = ConnectionListener()
 
     companion object {
         var enableLogging: Boolean = false
@@ -76,8 +76,6 @@ class PusherService : MChannel {
     }
 
     private fun init(call: MethodCall, result: Result) {
-        _connectionListener = ConnectionListener()
-
         // toString works because this is json encoded in dart
         val args = JSONObject(call.arguments.toString())
         val initArgs: JSONObject = args.getJSONObject("initArgs")

--- a/lib/src/contracts/stream_handler.dart
+++ b/lib/src/contracts/stream_handler.dart
@@ -12,6 +12,8 @@ abstract class StreamHandler {
   /// Add a listener to the event channel stream for pusher,
   /// any class that extends [StreamHandler] should use this method.
   void registerListener(String classId, dynamic Function(dynamic) method) {
+    _eventStreamSubscription?.cancel();
+
     StreamHandler._listeners[classId] = method;
 
     _eventStreamSubscription =

--- a/lib/src/pusher/pusher_client.dart
+++ b/lib/src/pusher/pusher_client.dart
@@ -57,7 +57,6 @@ class PusherClient extends StreamHandler {
   }
 
   Future _init(String appKey, PusherOptions options, InitArgs initArgs) async {
-    registerListener(classId, _eventHandler);
     await _channel.invokeMethod(
       'init',
       jsonEncode({
@@ -89,6 +88,8 @@ class PusherClient extends StreamHandler {
   /// Initiates a connection attempt using the client's
   /// existing connection details
   Future connect() async {
+    registerListener(classId, _eventHandler);
+
     await _channel.invokeMethod('connect');
   }
 


### PR DESCRIPTION
Currently on Android when doing:

```
pusher.connect()
pusher.disconnect()
pusher.connect()
```
we no longer receive onConnectionStateChange updates

This change will add or replace a streamsubscription on each connect(), which fixes the issue.
Also, each call to connect added another ConnectionListener instance which duplicated calls being sent to flutter, which should now be fixed.
