### PR TITLE
Fixed presence events `member_added` and `member_removed` not triggering for iOS

### DIFF
--- a/ios/Classes/ChannelEventListener.swift
+++ b/ios/Classes/ChannelEventListener.swift
@@ -15,14 +15,29 @@ class ChannelEventListener {
     
     func onEvent(event: PusherEvent) -> Void {
         let pusherEvent = Event(eventName: event.eventName, channelName: event.channelName, userId: event.userId, data: event.data)
-        
+        streamEvent(event: pusherEvent, logTag: "ON_EVENT")
+    }
+    
+    func onMemberAdded(channelName: String, member: PusherPresenceChannelMember) -> Void {
+        let eventName = Constants.PresenceEvents.memberAdded.rawValue
+        let pusherEvent = Event(eventName: eventName, channelName: channelName, userId: member.userId, data: "\(member.userInfo ?? "")")
+        streamEvent(event: pusherEvent, logTag: "ON_MEMBER_ADDED")
+    }
+    
+    func onMemberRemoved(channelName: String, member: PusherPresenceChannelMember) -> Void {
+        let eventName = Constants.PresenceEvents.memberRemoved.rawValue
+        let pusherEvent = Event(eventName: eventName, channelName: channelName, userId: member.userId, data: "\(member.userInfo ?? "")")
+        streamEvent(event: pusherEvent, logTag: "ON_MEMBER_REMOVED")
+    }
+    
+    private func streamEvent(event: Event, logTag: String) {
         do {
-            let data = try JSONEncoder().encode(EventStreamResult(pusherEvent: pusherEvent))
+            let data = try JSONEncoder().encode(EventStreamResult(pusherEvent: event))
             StreamHandler.Utils.eventSink!(String(data: data, encoding: .utf8))
             
-            PusherService.Utils.debugLog(msg: "[ON_EVENT] Channel: \(event.channelName ?? ""), EventName: \(event.eventName), Data: \(event.data ?? ""), User Id: \(event.userId ?? "")")
+            PusherService.Utils.debugLog(msg: "[\(logTag)] Channel: \(event.channelName ?? ""), EventName: \(event.eventName), User Id: \(event.userId ?? ""), Data: \(event.data ?? "")")
         } catch let err {
-            StreamHandler.Utils.eventSink!(FlutterError(code: "ON_EVENT_ERROR", message: err.localizedDescription, details: err))
+            StreamHandler.Utils.eventSink!(FlutterError(code: "\(logTag)_ERROR", message: err.localizedDescription, details: err))
         }
     }
 }

--- a/ios/Classes/PusherService.swift
+++ b/ios/Classes/PusherService.swift
@@ -122,7 +122,15 @@ class PusherService: MChannel {
         if(!channelName.starts(with: PusherService.PRESENCE_PREFIX)) {
             channel = _pusherInstance.subscribe(channelName)
         } else {
-            channel = _pusherInstance.subscribeToPresenceChannel(channelName: channelName)
+            channel = _pusherInstance.subscribeToPresenceChannel(
+                channelName: channelName,
+                onMemberAdded: { (member: PusherPresenceChannelMember) in
+                    ChannelEventListener.default.onMemberAdded(channelName: channelName, member: member)
+                },
+                onMemberRemoved: { (member: PusherPresenceChannelMember) in
+                    ChannelEventListener.default.onMemberRemoved(channelName: channelName, member: member)
+                }
+            )
             for pEvent in Constants.PresenceEvents.allCases {
                 channel.bind(eventName: pEvent.rawValue, eventCallback: ChannelEventListener.default.onEvent)
             }


### PR DESCRIPTION
Hi! Thanks for this library, using it with authenticated private and presence channels.

While using it, I stumbled upon an issue in iOS where it doesn't trigger the `pusher:member_added` and `pusher:member_removed` events at all with the presence channels. Making it impossible for the presence on iOS to know who joined or left.

Fixing that in this PR because it was never being triggered in Flutter for iOS and wanted to fix that to make it work.
The change made is that it uses the `onMemberAdded` and `onMemberRemoved` which the Pusher Swift SDK describes to register for these callbacks (see https://github.com/pusher/pusher-websocket-swift#swift-12).
Next, the event is published with the same name as we expect to the Flutter side, as done with the other events. 

This fixes the issue where the `pusher:member_added` and `pusher:member_removed` events are not being triggered.

When looking at the issues on the repo, I saw that #2 is facing the same issue in the first part of the issue. So this will also fix the first part of #2.

**Summary**
- [Flutter] No changes
- [Android] No changes
- [iOS] Internal change: Fixes `pusher:member_added` and `pusher:member_removed` usage when using presence channels

---

**Additional note** (Also related to #2)

_However, the data send with the `pusher:subscription_succeeded` event differs much from Android (except for the `user_id`). That is another issue, and matches to the second part of #2, the 'improvement' that is suggested there._
_I was also facing this issue when parsing the messages on Android. Currently still parsing the data manually in Flutter to fix this inconsistency._
