### PR TITLE
 Upgraded pusher-websocket-java 2.2.5 to 2.2.6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ android {
     }
 
     dependencies {
-        implementation "com.pusher:pusher-java-client:2.2.5"
+        implementation "com.pusher:pusher-java-client:2.2.6"
     }
 }
 


### PR DESCRIPTION
This fixes presence channel subscription bug that crashes applications