### PR TITLE
Nullify _pusherInstance on disconnect

### DIFF
--- a/android/src/main/kotlin/com/github/chinloyal/pusher_client/pusher/PusherService.kt
+++ b/android/src/main/kotlin/com/github/chinloyal/pusher_client/pusher/PusherService.kt
@@ -127,6 +127,7 @@ class PusherService : MChannel {
     private fun disconnect(result: Result) {
         _pusherInstance?.disconnect()
         debugLog("Disconnect")
+        _pusherInstance = null
         result.success(null)
     }
 


### PR DESCRIPTION
This is needed in order to be able to reset the pusher instance connection in case for example the auth token changes.