### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.github.chinloyal.pusher_client">
+  package="${applicationName}">
 </manifest>


### PR DESCRIPTION
Fix "Build failed due to use of deprecated Android v1 embedding" when building Flutter app